### PR TITLE
feat: set up gateway structure with service routes

### DIFF
--- a/server/gateway/index.ts
+++ b/server/gateway/index.ts
@@ -1,1 +1,0 @@
-// gateway/index.ts

--- a/server/gateway/package.json
+++ b/server/gateway/package.json
@@ -18,7 +18,11 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
+    "http-proxy-middleware": "^3.0.3",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.7.3"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17"
   }
 }

--- a/server/gateway/src/index.ts
+++ b/server/gateway/src/index.ts
@@ -1,0 +1,46 @@
+import dotenv from "dotenv";
+import express from "express";
+import cors from "cors";
+import { Request, Response, NextFunction } from "express";
+import authRoutes from "./routes/authRoutes";
+import socialRoutes from "./routes/socialRoutes";
+import marketRoutes from "./routes/marketRoutes";
+// import msgRoutes from "./routes/msgRoutes";
+
+// Load environment variables from .env file
+dotenv.config()
+
+// Initialize the express server
+const app = express();
+const GATEWAY_PORT: string | undefined = process.env.GATEWAY_PORT;
+if (!GATEWAY_PORT) {
+    throw new Error("Missing GATEWAY_PORT environment variable");
+}
+
+// Enable CORS
+app.use(cors());
+
+// Middleware for parsing JSON and URL-encoded data
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+
+// routes for each microservice
+app.use("/auth", authRoutes);
+app.use("/social", socialRoutes);
+app.use("/market", marketRoutes);
+// app.use("/message", msgRoutes);
+
+// Error handling middleware
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    console.error("Error occurred:", err.message);
+
+    res.status((err as any).status || 500).json({
+        success: false,
+        message: err.message || "Something went wrong. Try again later.",
+    });
+});
+
+// Start the server and listen on the specified port
+app.listen(GATEWAY_PORT, () => {
+    console.log(`Server running on port ${GATEWAY_PORT}`);
+});

--- a/server/gateway/src/routes/authRoutes.ts
+++ b/server/gateway/src/routes/authRoutes.ts
@@ -1,0 +1,23 @@
+import { Router } from "express";
+import { createProxyMiddleware } from "http-proxy-middleware";
+
+// Initialize auth router and get the service URL
+const authRoutes: Router = Router();
+const AUTH_SERVICE_URL: string | undefined = process.env.AUTH_SERVICE_URL;
+if (!AUTH_SERVICE_URL) {
+    throw new Error("Missing AUTH_SERVICE_URL environment variable")
+}
+
+// Proxy requests to the auth service
+authRoutes.use(
+    "/register",
+    createProxyMiddleware({
+        target: AUTH_SERVICE_URL,
+        changeOrigin: true,
+        pathRewrite: { "^/auth/register": "/register" },
+    })
+);
+
+// Add more routes as necessary
+
+export default authRoutes; 

--- a/server/gateway/src/routes/marketRoutes.ts
+++ b/server/gateway/src/routes/marketRoutes.ts
@@ -1,0 +1,23 @@
+import { Router } from "express";
+import { createProxyMiddleware } from "http-proxy-middleware";
+
+// Initialize market router and get the service URL
+const marketRoutes: Router = Router();
+const MARKET_SERVICE_URL: string | undefined = process.env.MARKET_SERVICE_URL;
+if (!MARKET_SERVICE_URL) {
+    throw new Error("Missing MARKET_SERVICE_URL environment variable")
+}
+
+// Proxy requests to the market service
+marketRoutes.use(
+    "/items",
+    createProxyMiddleware({
+        target: MARKET_SERVICE_URL,
+        changeOrigin: true,
+        pathRewrite: { "^/market/items": "/items" },
+    })
+);
+
+// Add more routes as necessary
+
+export default marketRoutes; 

--- a/server/gateway/src/routes/socialRoutes.ts
+++ b/server/gateway/src/routes/socialRoutes.ts
@@ -1,0 +1,23 @@
+import { Router } from "express";
+import { createProxyMiddleware } from "http-proxy-middleware";
+
+// Initialize social router and get the service URL
+const socialRoutes: Router = Router();
+const SOCIAL_SERVICE_URL: string | undefined = process.env.SOCIAL_SERVICE_URL;
+if (!SOCIAL_SERVICE_URL) {
+    throw new Error("Missing SOCIAL_SERVICE_URL environment variable")
+}
+
+// Proxy requests to the social service
+socialRoutes.use(
+    "/posts",
+    createProxyMiddleware({
+        target: SOCIAL_SERVICE_URL,
+        changeOrigin: true,
+        pathRewrite: { "^/social/posts": "/posts" },
+    })
+);
+
+// Add more routes as necessary
+
+export default socialRoutes; 

--- a/server/gateway/tsconfig.json
+++ b/server/gateway/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
@@ -9,9 +8,8 @@
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2016", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -23,9 +21,8 @@
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "commonjs", /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -44,12 +41,10 @@
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
     /* JavaScript Support */
     // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
     /* Emit */
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
@@ -72,18 +67,16 @@
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -103,9 +96,8 @@
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   }
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,25 @@
+{
+    "compilerOptions": {
+        "moduleResolution": "node", // Node module resolution strategy
+        "esModuleInterop": true, // Enable esModuleInterop for default imports
+        "skipLibCheck": true, // Skip checking of declaration files
+        "target": "esnext", // Set ECMAScript target
+        "module": "commonjs", // For Node.js compatibility
+        "strict": true, // Enable strict type-checking options
+        "baseUrl": ".", // Base directory for module resolution
+        "paths": {
+            "*": [
+                "node_modules/*"
+            ] // Customize module paths
+        }
+    },
+    "include": [
+        "gateway/src/**/*.ts", // Gateway's source files
+        "auth-service/src/**/*.ts", // Auth service source files
+        "social-service/src/**/*.ts", // Social service source files
+        "market-service/src/**/*.ts" // Market service source files
+    ],
+    "exclude": [
+        "node_modules" // Exclude node_modules from the build process
+    ]
+}


### PR DESCRIPTION
This PR sets up the basic structure for the gateway of our backend server. It establishes the foundation for proxying API calls from the client to the gateway and then to each microservice. Each route file for the services in the gateway (e.g., authRoutes.ts, socialRoutes.ts, and marketRoutes.ts) uses the general-purpose app.use() to allow each microservice to handle specific HTTP methods (GET, PUT, POST, DELETE, etc.). The gateway acts as an abstraction layer, delegating tasks to the microservices to maintain a modular and organized codebase.